### PR TITLE
Phase 1: CDC/MMWR epiweek

### DIFF
--- a/PR_PHASE1.md
+++ b/PR_PHASE1.md
@@ -1,0 +1,11 @@
+Implements CDC/MMWR epidemiological weeks as the default epiweek logic.
+
+Key points
+- Add `mmwr_week(date)` returning `(mmwr_year, mmwr_week)`.
+- Add `mmwr_week1_start(year)` (Sunday on/before Jan 4).
+- Add `parse_ymd()` to accept `YYYY-MM-DD` strings, `date`, or `datetime`.
+- Keep `calculate()` as backward-compatible wrapper returning week number only.
+- Replace prior week-0-based tests with focused MMWR boundary tests.
+
+Notes
+- This removes the old ISO-like "first Thursday" implementation and eliminates week 0 for MMWR logic.

--- a/PR_PHASE1_DEBATE.md
+++ b/PR_PHASE1_DEBATE.md
@@ -1,0 +1,33 @@
+Implements CDC/MMWR epidemiological weeks as the default epiweek logic.
+
+Key points
+- Add `mmwr_week(date)` returning `(mmwr_year, mmwr_week)`.
+- Add `mmwr_week1_start(year)` (Sunday on/before Jan 4).
+- Add `parse_ymd()` to accept `YYYY-MM-DD` strings, `date`, or `datetime`.
+- Keep `calculate()` as backward-compatible wrapper returning week number only.
+- Replace prior week-0-based tests with focused MMWR boundary tests.
+
+Why this implementation
+- CDC/MMWR weeks start on Sunday and Week 1 is defined as the week containing Jan 4. That implies Week 1 starts on the Sunday on/before Jan 4.
+- Computing `week1_start(year)` from Jan 4 is a simple, O(1) pure function that avoids tricky edge cases.
+- Returning `(mmwr_year, mmwr_week)` is essential because early January dates can belong to the previous MMWR year.
+- `parse_ymd()` centralizes date parsing/validation so later features (incidence curves, summaries) can reuse it.
+
+Multi-role debate (differences, not consensus)
+
+Role A — pragmatic developer
+- 👍 Likes: pure function, O(1), easy to test; `parse_ymd()` makes downstream code simpler.
+- ⚠️ Concern: backward-compat behavior changes for early-January dates (previously could be week 0; now becomes week 52/53). Correct for MMWR but can surprise users.
+
+Role B — architecture
+- 👍 Likes: explicit MMWR semantics; returning `(year, week)` avoids ambiguity.
+- ⚠️ Concern: module/API organization. Might prefer a `time/` namespace (e.g., `epydem.time.mmwr_week`) if we later add ISO/WHO week systems.
+
+Role C — developer user (DX)
+- 👍 Likes: no week 0; tuple output makes grouping across years correct.
+- ⚠️ Concern: naming. Users may want `epiweek()` as the default MMWR function and clear docs with boundary examples (e.g., 2022-01-01 -> (2021, 52)).
+
+Points of divergence to revisit later
+1) Naming: `mmwr_week()` vs providing a default `epiweek()` alias.
+2) Compatibility: keep `calculate()` returning week-only vs switching `calculate()` to tuple (breaking change).
+3) Structure: keep in `epiweek.py` vs split into `epydem/time.py` or `epydem/time/` module.

--- a/README.md
+++ b/README.md
@@ -25,9 +25,11 @@ pip install -e '.[dev]'
 ```python
 import epydem
 
-# Current API (will change):
-week_number = epydem.calculate("2024-01-01")
-print(week_number)
+year, week = epydem.epiweek("2024-01-01")
+print(year, week)
+
+week_only = epydem.epiweek_number("2024-01-01")
+print(week_only)
 ```
 
 ## Roadmap (high level)

--- a/epydem/__init__.py
+++ b/epydem/__init__.py
@@ -1,9 +1,12 @@
 """epydem public API."""
 
-from .epiweek import calculate, mmwr_week, mmwr_week1_start, parse_ymd
+from .epiweek import calculate
+from .time import epiweek, epiweek_number, mmwr_week, mmwr_week1_start, parse_ymd
 
 __all__ = [
     "calculate",
+    "epiweek",
+    "epiweek_number",
     "mmwr_week",
     "mmwr_week1_start",
     "parse_ymd",

--- a/epydem/epiweek.py
+++ b/epydem/epiweek.py
@@ -1,85 +1,19 @@
+"""Backward-compat module.
+
+Historically this project exposed `epydem.calculate()` from `epydem.epiweek`.
+We are moving time-related utilities to `epydem.time`.
+
+Prefer using:
+- `epydem.epiweek()` -> (year, week)
+- `epydem.epiweek_number()` -> week
+"""
+
 from __future__ import annotations
 
-import re
-from datetime import date, datetime, timedelta
-from typing import Tuple, Union
-
-DateLike = Union[str, date, datetime]
-
-
-_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
-
-
-def parse_ymd(value: DateLike) -> date:
-    """Parse a date-like value into a `datetime.date`.
-
-    Supported inputs:
-    - `datetime.date`
-    - `datetime.datetime` (date portion is used)
-    - `str` in YYYY-MM-DD format
-    """
-
-    if isinstance(value, datetime):
-        return value.date()
-    if isinstance(value, date):
-        return value
-    if isinstance(value, str):
-        if not _DATE_PATTERN.match(value):
-            raise ValueError("Invalid date format. Please use YYYY-MM-DD")
-        return datetime.strptime(value, "%Y-%m-%d").date()
-
-    raise TypeError(f"Unsupported type for date: {type(value)!r}")
-
-
-def mmwr_week1_start(year: int) -> date:
-    """Return the start date (Sunday) of MMWR week 1 for a given calendar year.
-
-    CDC/MMWR definition:
-    - Weeks start on Sunday.
-    - Week 1 is the week that contains January 4.
-
-    Therefore: week 1 starts on the Sunday on or before Jan 4.
-    """
-
-    jan4 = date(year, 1, 4)
-    # Python: Monday=0 .. Sunday=6. We need offset back to Sunday.
-    days_since_sunday = (jan4.weekday() + 1) % 7
-    return jan4 - timedelta(days=days_since_sunday)
-
-
-def mmwr_week(value: DateLike) -> Tuple[int, int]:
-    """Compute CDC/MMWR epidemiological week for a date.
-
-    Returns:
-        (mmwr_year, mmwr_week)
-
-    Notes:
-    - Weeks start Sunday.
-    - Week 1 is the week containing Jan 4.
-    - Dates in early January can belong to the previous MMWR year.
-    """
-
-    d = parse_ymd(value)
-
-    start_this_year = mmwr_week1_start(d.year)
-    if d < start_this_year:
-        mmwr_year = d.year - 1
-        start = mmwr_week1_start(mmwr_year)
-    else:
-        mmwr_year = d.year
-        start = start_this_year
-
-    week = ((d - start).days // 7) + 1
-    return mmwr_year, week
+from .time import epiweek, epiweek_number, mmwr_week, mmwr_week1_start, parse_ymd
 
 
 def calculate(date_str: str) -> int:
-    """Backward-compatible wrapper.
+    """Compatibility alias for week number only."""
 
-    Historically, `epydem.calculate()` returned a week number only.
-    Going forward, CDC/MMWR weeks are the default. For full fidelity,
-    use `mmwr_week()`.
-    """
-
-    _year, week = mmwr_week(date_str)
-    return week
+    return epiweek_number(date_str)

--- a/epydem/time.py
+++ b/epydem/time.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import re
+from datetime import date, datetime, timedelta
+from typing import Literal, Tuple, Union
+
+DateLike = Union[str, date, datetime]
+EpiWeekSystem = Literal["mmwr"]
+
+_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def parse_ymd(value: DateLike) -> date:
+    """Parse a date-like value into a `datetime.date`.
+
+    Supported inputs:
+    - `datetime.date`
+    - `datetime.datetime` (date portion is used)
+    - `str` in YYYY-MM-DD format
+    """
+
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        if not _DATE_PATTERN.match(value):
+            raise ValueError("Invalid date format. Please use YYYY-MM-DD")
+        return datetime.strptime(value, "%Y-%m-%d").date()
+
+    raise TypeError(f"Unsupported type for date: {type(value)!r}")
+
+
+def mmwr_week1_start(year: int) -> date:
+    """Start date (Sunday) of CDC/MMWR week 1 for the given calendar year.
+
+    CDC/MMWR definition:
+    - Weeks start on Sunday.
+    - Week 1 is the week that contains January 4.
+
+    Therefore: week 1 starts on the Sunday on or before Jan 4.
+    """
+
+    jan4 = date(year, 1, 4)
+    # Python weekday: Monday=0 .. Sunday=6. Offset back to Sunday.
+    days_since_sunday = (jan4.weekday() + 1) % 7
+    return jan4 - timedelta(days=days_since_sunday)
+
+
+def mmwr_week(value: DateLike) -> Tuple[int, int]:
+    """Compute CDC/MMWR epidemiological week for a date.
+
+    Returns:
+        (mmwr_year, mmwr_week)
+
+    Notes:
+    - Weeks start Sunday.
+    - Week 1 is the week containing Jan 4.
+    - Dates in early January can belong to the previous MMWR year.
+    """
+
+    d = parse_ymd(value)
+    start_this_year = mmwr_week1_start(d.year)
+
+    if d < start_this_year:
+        mmwr_year = d.year - 1
+        start = mmwr_week1_start(mmwr_year)
+    else:
+        mmwr_year = d.year
+        start = start_this_year
+
+    week = ((d - start).days // 7) + 1
+    return mmwr_year, week
+
+
+def epiweek(value: DateLike, system: EpiWeekSystem = "mmwr") -> Tuple[int, int]:
+    """Compute epidemiological week.
+
+    Currently supported systems:
+    - "mmwr" (CDC/MMWR): week starts Sunday, week 1 contains Jan 4.
+
+    Returns:
+        (epi_year, epi_week)
+
+    Rationale for returning a tuple:
+    - Epi week numbering crosses calendar-year boundaries.
+    - A week number alone is ambiguous without its epidemiological year.
+    """
+
+    if system == "mmwr":
+        return mmwr_week(value)
+    raise ValueError(f"Unknown epiweek system: {system}")
+
+
+def epiweek_number(value: DateLike, system: EpiWeekSystem = "mmwr") -> int:
+    """Convenience wrapper returning week number only."""
+
+    _y, w = epiweek(value, system=system)
+    return w

--- a/tests/test_epiweek.py
+++ b/tests/test_epiweek.py
@@ -26,29 +26,29 @@ class TestParseYmd:
             epydem.parse_ymd(20240101)  # type: ignore[arg-type]
 
 
-class TestMmwrWeek:
+class TestEpiweekMmwr:
     def test_week1_contains_jan4(self):
         # MMWR week 1 starts on Sunday on/before Jan 4.
         assert epydem.mmwr_week1_start(2024) == date(2023, 12, 31)
         assert epydem.mmwr_week1_start(2023) == date(2023, 1, 1)
         assert epydem.mmwr_week1_start(2022) == date(2022, 1, 2)
 
-    def test_known_boundaries(self):
+    def test_known_boundaries_tuple_output(self):
         # Early January can belong to previous MMWR year.
-        assert epydem.mmwr_week("2022-01-01") == (2021, 52)
-        assert epydem.mmwr_week("2022-01-02") == (2022, 1)
+        assert epydem.epiweek("2022-01-01") == (2021, 52)
+        assert epydem.epiweek("2022-01-02") == (2022, 1)
 
         # New year transitions.
-        assert epydem.mmwr_week("2023-01-01") == (2023, 1)
-        assert epydem.mmwr_week("2023-12-31") == (2023, 53)
+        assert epydem.epiweek("2023-01-01") == (2023, 1)
+        assert epydem.epiweek("2023-12-31") == (2023, 53)
 
-        assert epydem.mmwr_week("2024-01-01") == (2024, 1)
-        assert epydem.mmwr_week("2024-01-07") == (2024, 2)
-        assert epydem.mmwr_week("2024-12-31") == (2024, 53)
+        assert epydem.epiweek("2024-01-01") == (2024, 1)
+        assert epydem.epiweek("2024-01-07") == (2024, 2)
+        assert epydem.epiweek("2024-12-31") == (2024, 53)
 
-        assert epydem.mmwr_week("2026-01-01") == (2025, 53)
+        assert epydem.epiweek("2026-01-01") == (2025, 53)
 
-    def test_calculate_is_backward_compatible(self):
-        # calculate() returns week number only.
+    def test_week_number_wrapper(self):
+        assert epydem.epiweek_number("2024-01-01") == 1
         assert epydem.calculate("2024-01-01") == 1
         assert epydem.calculate("2022-01-01") == 52


### PR DESCRIPTION
Implements CDC/MMWR epidemiological weeks as the default epiweek logic.

Key points
- Add `mmwr_week(date)` returning `(mmwr_year, mmwr_week)`.
- Add `mmwr_week1_start(year)` (Sunday on/before Jan 4).
- Add `parse_ymd()` to accept `YYYY-MM-DD` strings, `date`, or `datetime`.
- Keep `calculate()` as backward-compatible wrapper returning week number only.
- Replace prior week-0-based tests with focused MMWR boundary tests.

Why this implementation
- CDC/MMWR weeks start on Sunday and Week 1 is defined as the week containing Jan 4. That implies Week 1 starts on the Sunday on/before Jan 4.
- Computing `week1_start(year)` from Jan 4 is a simple, O(1) pure function that avoids tricky edge cases.
- Returning `(mmwr_year, mmwr_week)` is essential because early January dates can belong to the previous MMWR year.
- `parse_ymd()` centralizes date parsing/validation so later features (incidence curves, summaries) can reuse it.

Multi-role debate (differences, not consensus)

Role A — pragmatic developer
- 👍 Likes: pure function, O(1), easy to test; `parse_ymd()` makes downstream code simpler.
- ⚠️ Concern: backward-compat behavior changes for early-January dates (previously could be week 0; now becomes week 52/53). Correct for MMWR but can surprise users.

Role B — architecture
- 👍 Likes: explicit MMWR semantics; returning `(year, week)` avoids ambiguity.
- ⚠️ Concern: module/API organization. Might prefer a `time/` namespace (e.g., `epydem.time.mmwr_week`) if we later add ISO/WHO week systems.

Role C — developer user (DX)
- 👍 Likes: no week 0; tuple output makes grouping across years correct.
- ⚠️ Concern: naming. Users may want `epiweek()` as the default MMWR function and clear docs with boundary examples (e.g., 2022-01-01 -> (2021, 52)).

Points of divergence to revisit later
1) Naming: `mmwr_week()` vs providing a default `epiweek()` alias.
2) Compatibility: keep `calculate()` returning week-only vs switching `calculate()` to tuple (breaking change).
3) Structure: keep in `epiweek.py` vs split into `epydem/time.py` or `epydem/time/` module.
